### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,5 +24,5 @@ Documentation
 -------------
 
 You can find additional documentation on the django CMS within the `Aldryn Bootstrap Boilerplate
-<https://aldryn-boilerplate-bootstrap3.readthedocs.org>`_ or the `django CMS Documentation
-<https://django-cms.readthedocs.org>`_.
+<https://aldryn-boilerplate-bootstrap3.readthedocs.io>`_ or the `django CMS Documentation
+<https://django-cms.readthedocs.io>`_.


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
